### PR TITLE
replace deprecated matplotlib.nxutils

### DIFF
--- a/distmesh/distance_functions.py
+++ b/distmesh/distance_functions.py
@@ -101,8 +101,8 @@ def dpoly(p,pv):
     pv should be provided as a list of coordinates [(x0,y0), (x1,y1), ...]
     or an array of shape (nv, 2).
     """
-    from matplotlib.nxutils import points_inside_poly
-    return (-1)**points_inside_poly(p, pv) * dsegment(p, pv).min(1)
+    from matplotlib.path import Path
+    return (-1)**Path(pv).contains_points(p) * dsegment(p, pv).min(1)
 
 def drectangle0(p,x1,x2,y1,y2):
     """Signed distance function for rectangle with corners (x1,y1), (x2,y1),


### PR DESCRIPTION
Update to `matplotlib` [version 1.3.0+](http://matplotlib.org/1.3.0/api/api_changes.html) where `matplotlib.nxutils` [doesn't exist any more](http://matplotlib.org/1.2.1/api/nxutils_api.html), discussed also [here](http://stackoverflow.com/questions/13375957/python-running-matplotlib-nxutils-points-inside-poly-on-mac/13386468#13386468).
